### PR TITLE
refactor: [go] replace the generic to specific type when creating jwt

### DIFF
--- a/go/demo_eventticket.go
+++ b/go/demo_eventticket.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -340,8 +341,8 @@ func (d *demoEventticket) createJwtNewObjects(issuerId, classSuffix, objectSuffi
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"eventTicketClasses": [%s],
+		"eventTicketObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 

--- a/go/demo_flight.go
+++ b/go/demo_flight.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -320,8 +321,8 @@ func (d *demoFlight) createJwtNewObjects(issuerId, classSuffix, objectSuffix str
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"flightClasses": [%s],
+		"flightObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 

--- a/go/demo_giftcard.go
+++ b/go/demo_giftcard.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -288,8 +289,8 @@ func (d *demoGiftcard) createJwtNewObjects(issuerId, classSuffix, objectSuffix s
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"giftCardClasses": [%s],
+		"giftCardObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 

--- a/go/demo_loyalty.go
+++ b/go/demo_loyalty.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -310,8 +311,8 @@ func (d *demoLoyalty) createJwtNewObjects(issuerId, classSuffix, objectSuffix st
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"loyaltyClasses": [%s],
+		"loyaltyObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 

--- a/go/demo_offer.go
+++ b/go/demo_offer.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -292,8 +293,8 @@ func (d *demoOffer) createJwtNewObjects(issuerId, classSuffix, objectSuffix stri
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"offerClasses": [%s],
+		"offerObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 

--- a/go/demo_transit.go
+++ b/go/demo_transit.go
@@ -22,15 +22,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	oauthJwt "golang.org/x/oauth2/jwt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
 )
 
 // [END imports]
@@ -348,8 +349,8 @@ func (d *demoTransit) createJwtNewObjects(issuerId, classSuffix, objectSuffix st
 	var payload map[string]interface{}
 	json.Unmarshal([]byte(fmt.Sprintf(`
 	{
-		"genericClasses": [%s],
-		"genericObjects": [%s]
+		"transitClasses": [%s],
+		"transitObjects": [%s]
 	}
 	`, newClass, newObject)), &payload)
 


### PR DESCRIPTION
When creating new JWT objects for payload, the classes and object type are using "generic" instead of their actual type.
Imports are moved by auto format.