### PR TITLE
Remove Walletobjects.php manual dependency

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -18,7 +18,7 @@ creating a pass class, updating issuer permissions, and more.
 
 ## Prerequisites
 
-*   PHP 8.x
+*   PHP 7.4
 *   Composer 2.x
 *   Follow the steps outlined in the
     [Google Wallet prerequisites](https://developers.google.com/wallet/generic/web/prerequisites)

--- a/php/README.md
+++ b/php/README.md
@@ -23,8 +23,6 @@ creating a pass class, updating issuer permissions, and more.
 *   Follow the steps outlined in the
     [Google Wallet prerequisites](https://developers.google.com/wallet/generic/web/prerequisites)
     to create the Google Wallet issuer account and Google Cloud service account
-*   Download the PHP
-    [Google Wallet API Client library](https://developers.google.com/wallet/generic/resources/libraries#php)
 
 ## Environment variables
 
@@ -45,17 +43,7 @@ for each class file.
     composer install
     ```
 
-2.  Copy the path to the Google Wallet API Client library (`Walletobjects.php`
-    file) you downloaded. If needed, update the path in the demo class PHP file
-    (line 22).
-
-    ```php
-    // Download the PHP client library from the following URL
-    // https://developers.google.com/wallet/generic/resources/libraries
-    require __DIR__ . '/lib/Walletobjects.php';
-    ```
-
-3.  In your PHP code, import a demo class and call its method(s). An example
+2.  In your PHP code, import a demo class and call its method(s). An example
     can be found below
 
     ```php

--- a/php/README.md
+++ b/php/README.md
@@ -48,44 +48,47 @@ for each class file.
 
     ```php
     // Import the demo class
-    require __DIR__ . 'demo_eventticket.php';
+    require __DIR__ . '/demo_eventticket.php';
+
+    // Your Issuer account ID (@see Prerequisites)
+    $issuerId = '3388000000000000000';
 
     // Create a demo class instance
     $demo = new DemoEventTicket();
 
     // Create a pass class
-    $demo->createClass('issuer_id', 'class_suffix');
+    $demo->createClass($issuerId, 'class_suffix');
 
     // Update a pass class
-    $demo->updateClass('issuer_id', 'class_suffix');
+    $demo->updateClass($issuerId, 'class_suffix');
 
     // Patch a pass class
-    $demo->patchClass('issuer_id', 'class_suffix');
+    $demo->patchClass($issuerId, 'class_suffix');
 
     // Add a message to a pass class
-    $demo->addClassMessage('issuer_id', 'class_suffix', 'header', 'body');
+    $demo->addClassMessage($issuerId, 'class_suffix', 'header', 'body');
 
     // Create a pass object
-    $demo->createObject('issuer_id', 'class_suffix', 'object_suffix');
+    $demo->createObject($issuerId, 'class_suffix', 'object_suffix');
 
     // Update a pass object
-    $demo->updateObject('issuer_id', 'object_suffix');
+    $demo->updateObject($issuerId, 'object_suffix');
 
     // Patch a pass object
-    $demo->patchObject('issuer_id', 'object_suffix');
+    $demo->patchObject($issuerId, 'object_suffix');
 
     // Add a message to a pass object
-    $demo->addObjectMessage('issuer_id', 'object_suffix', 'header', 'body');
+    $demo->addObjectMessage($issuerId, 'object_suffix', 'header', 'body');
 
     // Expire a pass object
-    $demo->expireObject('issuer_id', 'object_suffix');
+    $demo->expireObject($issuerId, 'object_suffix');
 
     // Generate an Add to Google Wallet link that creates a new pass class and object
-    $demo->createJWTNewObjects('issuer_id', 'class_suffix', 'object_suffix');
+    $demo->createJWTNewObjects($issuerId, 'class_suffix', 'object_suffix');
 
     // Generate an Add to Google Wallet link that references existing pass object(s)
-    $demo->createJWTExistingObjects('issuer_id');
+    $demo->createJWTExistingObjects($issuerId);
 
     // Create pass objects in batch
-    $demo->batchCreateObjects('issuer_id', 'class_suffix');
+    $demo->batchCreateObjects($issuerId, 'class_suffix');
     ```

--- a/php/composer.json
+++ b/php/composer.json
@@ -2,6 +2,15 @@
   "require": {
     "google/auth": "^1.18",
     "guzzlehttp/guzzle": "*",
-    "google/apiclient": "^2.12"
+    "google/apiclient": "^2.15",
+    "google/apiclient-services": "~0.300"
+  },
+  "scripts": {
+    "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
+  },
+  "extra": {
+    "google/apiclient-services": [
+      "Walletobjects"
+    ]
   }
 }

--- a/php/demo_eventticket.php
+++ b/php/demo_eventticket.php
@@ -17,20 +17,38 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\EventSeat;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\EventTicketObject;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\EventTicketClass;
 // [END imports]
 
 /** Demo class for creating and managing Event tickets in Google Wallet. */
 class DemoEventTicket
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +63,7 @@ class DemoEventTicket
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +87,12 @@ class DemoEventTicket
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,10 +123,10 @@ class DemoEventTicket
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass
-    $newClass = new Google_Service_Walletobjects_EventTicketClass([
+    $newClass = new EventTicketClass([
       'eventId' => "{$issuerId}.{$classSuffix}",
-      'eventName' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'eventName' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Event name'
         ])
@@ -156,7 +174,7 @@ class DemoEventTicket
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]));
@@ -202,8 +220,8 @@ class DemoEventTicket
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_EventTicketClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new EventTicketClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -249,8 +267,8 @@ class DemoEventTicket
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -293,36 +311,36 @@ class DemoEventTicket
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/events/rest/v1/eventticketobject
-    $newObject = new Google_Service_Walletobjects_EventTicketObject([
+    $newObject = new EventTicketObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -330,13 +348,13 @@ class DemoEventTicket
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -345,37 +363,37 @@ class DemoEventTicket
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
-      'seatInfo' => new Google_Service_Walletobjects_EventSeat([
-        'seat' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'seatInfo' => new EventSeat([
+        'seat' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => '42'
           ])
         ]),
-        'row' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'row' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'G3'
           ])
         ]),
-        'section' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'section' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => '5'
           ])
         ]),
-        'gate' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'gate' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'A'
           ])
@@ -422,7 +440,7 @@ class DemoEventTicket
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -430,7 +448,7 @@ class DemoEventTicket
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -478,17 +496,17 @@ class DemoEventTicket
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_EventTicketObject();
+    $patchBody = new EventTicketObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -539,7 +557,7 @@ class DemoEventTicket
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_EventTicketObject([
+    $patchBody = new EventTicketObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -579,8 +597,8 @@ class DemoEventTicket
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -614,12 +632,12 @@ class DemoEventTicket
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/events/rest/v1/eventticketclass
-    $newClass = new Google_Service_Walletobjects_EventTicketClass([
+    $newClass = new EventTicketClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
-      'eventName' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'eventName' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Event name'
         ])
@@ -628,36 +646,36 @@ class DemoEventTicket
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/events/rest/v1/eventticketobject
-    $newObject = new Google_Service_Walletobjects_EventTicketObject([
+    $newObject = new EventTicketObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -665,13 +683,13 @@ class DemoEventTicket
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -680,37 +698,37 @@ class DemoEventTicket
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
-      'seatInfo' => new Google_Service_Walletobjects_EventSeat([
-        'seat' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'seatInfo' => new EventSeat([
+        'seat' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => '42'
           ])
         ]),
-        'row' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'row' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'G3'
           ])
         ]),
-        'section' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'section' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => '5'
           ])
         ]),
-        'gate' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'gate' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'A'
           ])
@@ -880,36 +898,36 @@ class DemoEventTicket
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/tickets/events/rest/v1/eventticketobject
-      $batchObject = new Google_Service_Walletobjects_EventTicketObject([
+      $batchObject = new EventTicketObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -917,13 +935,13 @@ class DemoEventTicket
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -932,37 +950,37 @@ class DemoEventTicket
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
         ],
-        'seatInfo' => new Google_Service_Walletobjects_EventSeat([
-          'seat' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'seatInfo' => new EventSeat([
+          'seat' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => '42'
             ])
           ]),
-          'row' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'row' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'G3'
             ])
           ]),
-          'section' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'section' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => '5'
             ])
           ]),
-          'gate' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'gate' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'A'
             ])

--- a/php/demo_eventticket.php
+++ b/php/demo_eventticket.php
@@ -79,17 +79,15 @@ class DemoEventTicket
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_flight.php
+++ b/php/demo_flight.php
@@ -17,20 +17,42 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\ReservationInfo;
+use Google\Service\Walletobjects\BoardingAndSeatingInfo;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\FlightObject;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
+use Google\Service\Walletobjects\AirportInfo;
+use Google\Service\Walletobjects\FlightCarrier;
+use Google\Service\Walletobjects\FlightClass;
+use Google\Service\Walletobjects\FlightHeader;
 // [END imports]
 
 /** Demo class for creating and managing Flights in Google Wallet. */
 class DemoFlight
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +67,7 @@ class DemoFlight
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +91,12 @@ class DemoFlight
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,23 +127,23 @@ class DemoFlight
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/boarding-passes/rest/v1/flightclass
-    $newClass = new Google_Service_Walletobjects_FlightClass([
+    $newClass = new FlightClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
       'localScheduledDepartureDateTime' => '2023-07-02T15:30:00',
-      'flightHeader' => new Google_Service_Walletobjects_FlightHeader([
-        'carrier' => new Google_Service_Walletobjects_FlightCarrier([
+      'flightHeader' => new FlightHeader([
+        'carrier' => new FlightCarrier([
           'carrierIataCode' => 'LX'
         ]),
         'flightNumber' => '123'
       ]),
-      'origin' => new Google_Service_Walletobjects_AirportInfo([
+      'origin' => new AirportInfo([
         'airportIataCode' => 'LAX',
         'terminal' => '1',
         'gate' => 'A2'
       ]),
-      'destination' => new Google_Service_Walletobjects_AirportInfo([
+      'destination' => new AirportInfo([
         'airportIataCode' => 'SFO',
         'terminal' => '2',
         'gate' => 'C3'
@@ -166,7 +188,7 @@ class DemoFlight
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]));
@@ -212,8 +234,8 @@ class DemoFlight
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_FlightClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new FlightClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -259,8 +281,8 @@ class DemoFlight
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -303,36 +325,36 @@ class DemoFlight
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/boarding-passes/rest/v1/flightobject
-    $newObject = new Google_Service_Walletobjects_FlightObject([
+    $newObject = new FlightObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -340,13 +362,13 @@ class DemoFlight
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -355,22 +377,22 @@ class DemoFlight
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'passengerName' => 'Passenger name',
-      'boardingAndSeatingInfo' => new Google_Service_Walletobjects_BoardingAndSeatingInfo([
+      'boardingAndSeatingInfo' => new BoardingAndSeatingInfo([
         'boardingGroup' => 'B',
         'seatNumber' => '42'
       ]),
-      'reservationInfo' => new Google_Service_Walletobjects_ReservationInfo([
+      'reservationInfo' => new ReservationInfo([
         'confirmationCode' => 'Confirmation code'
       ])
     ]);
@@ -412,7 +434,7 @@ class DemoFlight
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -420,7 +442,7 @@ class DemoFlight
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -468,17 +490,17 @@ class DemoFlight
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_FlightObject();
+    $patchBody = new FlightObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -529,7 +551,7 @@ class DemoFlight
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_FlightObject([
+    $patchBody = new FlightObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -569,8 +591,8 @@ class DemoFlight
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -604,23 +626,23 @@ class DemoFlight
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/boarding-passes/rest/v1/flightclass
-    $newClass = new Google_Service_Walletobjects_FlightClass([
+    $newClass = new FlightClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
       'localScheduledDepartureDateTime' => '2023-07-02T15:30:00',
-      'flightHeader' => new Google_Service_Walletobjects_FlightHeader([
-        'carrier' => new Google_Service_Walletobjects_FlightCarrier([
+      'flightHeader' => new FlightHeader([
+        'carrier' => new FlightCarrier([
           'carrierIataCode' => 'LX'
         ]),
         'flightNumber' => '123'
       ]),
-      'origin' => new Google_Service_Walletobjects_AirportInfo([
+      'origin' => new AirportInfo([
         'airportIataCode' => 'LAX',
         'terminal' => '1',
         'gate' => 'A2'
       ]),
-      'destination' => new Google_Service_Walletobjects_AirportInfo([
+      'destination' => new AirportInfo([
         'airportIataCode' => 'SFO',
         'terminal' => '2',
         'gate' => 'C3'
@@ -629,36 +651,36 @@ class DemoFlight
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/boarding-passes/rest/v1/flightobject
-    $newObject = new Google_Service_Walletobjects_FlightObject([
+    $newObject = new FlightObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -666,13 +688,13 @@ class DemoFlight
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -681,22 +703,22 @@ class DemoFlight
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'passengerName' => 'Passenger name',
-      'boardingAndSeatingInfo' => new Google_Service_Walletobjects_BoardingAndSeatingInfo([
+      'boardingAndSeatingInfo' => new BoardingAndSeatingInfo([
         'boardingGroup' => 'B',
         'seatNumber' => '42'
       ]),
-      'reservationInfo' => new Google_Service_Walletobjects_ReservationInfo([
+      'reservationInfo' => new ReservationInfo([
         'confirmationCode' => 'Confirmation code'
       ])
     ]);
@@ -861,36 +883,36 @@ class DemoFlight
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/tickets/boarding-passes/rest/v1/flightobject
-      $batchObject = new Google_Service_Walletobjects_FlightObject([
+      $batchObject = new FlightObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -898,13 +920,13 @@ class DemoFlight
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -913,22 +935,22 @@ class DemoFlight
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
         ],
         'passengerName' => 'Passenger name',
-        'boardingAndSeatingInfo' => new Google_Service_Walletobjects_BoardingAndSeatingInfo([
+        'boardingAndSeatingInfo' => new BoardingAndSeatingInfo([
           'boardingGroup' => 'B',
           'seatNumber' => '42'
         ]),
-        'reservationInfo' => new Google_Service_Walletobjects_ReservationInfo([
+        'reservationInfo' => new ReservationInfo([
           'confirmationCode' => 'Confirmation code'
         ])
       ]);

--- a/php/demo_flight.php
+++ b/php/demo_flight.php
@@ -83,17 +83,15 @@ class DemoFlight
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_generic.php
+++ b/php/demo_generic.php
@@ -75,17 +75,15 @@ class DemoGeneric
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_generic.php
+++ b/php/demo_generic.php
@@ -17,20 +17,34 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\GenericObject;
+use Google\Service\Walletobjects\GenericClass;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\Uri;
 // [END imports]
 
 /** Demo class for creating and managing Generic passes in Google Wallet. */
 class DemoGeneric
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +59,7 @@ class DemoGeneric
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +83,12 @@ class DemoGeneric
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,7 +119,7 @@ class DemoGeneric
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/generic/rest/v1/genericclass
-    $newClass = new Google_Service_Walletobjects_GenericClass([
+    $newClass = new GenericClass([
       'id' => "{$issuerId}.{$classSuffix}"
     ]);
 
@@ -147,7 +161,7 @@ class DemoGeneric
     }
 
     // Update the class by adding a homepage
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]);
@@ -155,7 +169,7 @@ class DemoGeneric
     $linksModuleData = $updatedClass->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -206,17 +220,17 @@ class DemoGeneric
     }
 
     // Patch the class by adding a homepage
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_GenericClass();
+    $patchBody = new GenericClass();
 
     $linksModuleData = $existingClass->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -266,36 +280,36 @@ class DemoGeneric
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/generic/rest/v1/genericobject
-    $newObject = new Google_Service_Walletobjects_GenericObject([
+    $newObject = new GenericObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -303,13 +317,13 @@ class DemoGeneric
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -318,29 +332,29 @@ class DemoGeneric
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
-      'cardTitle' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'cardTitle' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Generic card title'
         ])
       ]),
-      'header' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'header' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Generic header'
         ])
       ]),
       'hexBackgroundColor' => '#4285f4',
-      'logo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'logo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://storage.googleapis.com/wallet-lab-tools-codelab-artifacts-public/pass_google_logo.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Generic card logo'
           ])
@@ -385,7 +399,7 @@ class DemoGeneric
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -393,7 +407,7 @@ class DemoGeneric
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -441,17 +455,17 @@ class DemoGeneric
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_GenericObject();
+    $patchBody = new GenericObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -502,7 +516,7 @@ class DemoGeneric
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_GenericObject([
+    $patchBody = new GenericObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -534,42 +548,42 @@ class DemoGeneric
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/generic/rest/v1/genericclass
-    $newClass = new Google_Service_Walletobjects_GenericClass([
+    $newClass = new GenericClass([
       'id' => "{$issuerId}.{$classSuffix}",
     ]);
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/generic/rest/v1/genericobject
-    $newObject = new Google_Service_Walletobjects_GenericObject([
+    $newObject = new GenericObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -577,13 +591,13 @@ class DemoGeneric
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -592,29 +606,29 @@ class DemoGeneric
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
-      'cardTitle' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'cardTitle' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Generic card title'
         ])
       ]),
-      'header' => new Google_Service_Walletobjects_LocalizedString([
-        'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+      'header' => new LocalizedString([
+        'defaultValue' => new TranslatedString([
           'language' => 'en-US',
           'value' => 'Generic header'
         ])
       ]),
       'hexBackgroundColor' => '#4285f4',
-      'logo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'logo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://storage.googleapis.com/wallet-lab-tools-codelab-artifacts-public/pass_google_logo.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Generic card logo'
           ])
@@ -782,36 +796,36 @@ class DemoGeneric
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/generic/rest/v1/genericobject
-      $batchObject = new Google_Service_Walletobjects_GenericObject([
+      $batchObject = new GenericObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -819,13 +833,13 @@ class DemoGeneric
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -834,29 +848,29 @@ class DemoGeneric
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
-        'cardTitle' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'cardTitle' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Generic card title'
           ])
         ]),
-        'header' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'header' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Generic header'
           ])
         ]),
         'hexBackgroundColor' => '#4285f4',
-        'logo' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'logo' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://storage.googleapis.com/wallet-lab-tools-codelab-artifacts-public/pass_google_logo.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Generic card logo'
             ])

--- a/php/demo_giftcard.php
+++ b/php/demo_giftcard.php
@@ -80,17 +80,15 @@ class DemoGiftCard
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);
@@ -110,7 +108,7 @@ class DemoGiftCard
   {
     // Check if the class exists
     try {
-      $this->service->eventticketclass->get("{$issuerId}.{$classSuffix}");
+      $this->service->giftcardclass->get("{$issuerId}.{$classSuffix}");
 
       print("Class {$issuerId}.{$classSuffix} already exists!");
       return "{$issuerId}.{$classSuffix}";

--- a/php/demo_giftcard.php
+++ b/php/demo_giftcard.php
@@ -17,20 +17,39 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\DateTime;
+use Google\Service\Walletobjects\Money;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\GiftCardObject;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
+use Google\Service\Walletobjects\GiftCardClass;
 // [END imports]
 
 /** Demo class for creating and managing Gift cards in Google Wallet. */
 class DemoGiftCard
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +64,7 @@ class DemoGiftCard
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +88,12 @@ class DemoGiftCard
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,7 +124,7 @@ class DemoGiftCard
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardclass
-    $newClass = new Google_Service_Walletobjects_GiftCardClass([
+    $newClass = new GiftCardClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW'
@@ -149,7 +168,7 @@ class DemoGiftCard
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]));
@@ -195,8 +214,8 @@ class DemoGiftCard
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_GiftCardClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new GiftCardClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -242,8 +261,8 @@ class DemoGiftCard
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -286,36 +305,36 @@ class DemoGiftCard
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardobject
-    $newObject = new Google_Service_Walletobjects_GiftCardObject([
+    $newObject = new GiftCardObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -323,13 +342,13 @@ class DemoGiftCard
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -338,23 +357,23 @@ class DemoGiftCard
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'cardNumber' => 'Card number',
       'pin' => '1234',
-      'balance' => new Google_Service_Walletobjects_Money([
+      'balance' => new Money([
         'micros' => 20000000,
         'currencyCode' => 'USD'
       ]),
-      'balanceUpdateTime' => new Google_Service_Walletobjects_DateTime([
+      'balanceUpdateTime' => new DateTime([
         'date' => '2020-04-12T16:20:50.52-04:00'
       ])
     ]);
@@ -396,7 +415,7 @@ class DemoGiftCard
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -404,7 +423,7 @@ class DemoGiftCard
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -452,17 +471,17 @@ class DemoGiftCard
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_GiftCardObject();
+    $patchBody = new GiftCardObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -513,7 +532,7 @@ class DemoGiftCard
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_GiftCardObject([
+    $patchBody = new GiftCardObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -553,8 +572,8 @@ class DemoGiftCard
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -588,7 +607,7 @@ class DemoGiftCard
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardclass
-    $newClass = new Google_Service_Walletobjects_GiftCardClass([
+    $newClass = new GiftCardClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW'
@@ -596,36 +615,36 @@ class DemoGiftCard
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardobject
-    $newObject = new Google_Service_Walletobjects_GiftCardObject([
+    $newObject = new GiftCardObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -633,13 +652,13 @@ class DemoGiftCard
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -648,23 +667,23 @@ class DemoGiftCard
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'cardNumber' => 'Card number',
       'pin' => '1234',
-      'balance' => new Google_Service_Walletobjects_Money([
+      'balance' => new Money([
         'micros' => 20000000,
         'currencyCode' => 'USD'
       ]),
-      'balanceUpdateTime' => new Google_Service_Walletobjects_DateTime([
+      'balanceUpdateTime' => new DateTime([
         'date' => '2020-04-12T16:20:50.52-04:00'
       ])
     ]);
@@ -829,36 +848,36 @@ class DemoGiftCard
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/retail/gift-cards/rest/v1/giftcardobject
-      $batchObject = new Google_Service_Walletobjects_GiftCardObject([
+      $batchObject = new GiftCardObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -866,13 +885,13 @@ class DemoGiftCard
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -881,23 +900,23 @@ class DemoGiftCard
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
         ],
         'cardNumber' => 'Card number',
         'pin' => '1234',
-        'balance' => new Google_Service_Walletobjects_Money([
+        'balance' => new Money([
           'micros' => 20000000,
           'currencyCode' => 'USD'
         ]),
-        'balanceUpdateTime' => new Google_Service_Walletobjects_DateTime([
+        'balanceUpdateTime' => new DateTime([
           'date' => '2020-04-12T16:20:50.52-04:00'
         ])
       ]);

--- a/php/demo_loyalty.php
+++ b/php/demo_loyalty.php
@@ -17,20 +17,39 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\LoyaltyPointsBalance;
+use Google\Service\Walletobjects\LoyaltyPoints;
+use Google\Service\Walletobjects\LoyaltyObject;
+use Google\Service\Walletobjects\LoyaltyClass;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
 // [END imports]
 
 /** Demo class for creating and managing Loyalty cards in Google Wallet. */
 class DemoLoyalty
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +64,7 @@ class DemoLoyalty
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +88,12 @@ class DemoLoyalty
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,17 +124,17 @@ class DemoLoyalty
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass
-    $newClass = new Google_Service_Walletobjects_LoyaltyClass([
+    $newClass = new LoyaltyClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
       'programName' => 'Program name',
-      'programLogo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'programLogo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'http://farm8.staticflickr.com/7340/11177041185_a61a7f2139_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Logo description'
           ])
@@ -162,7 +181,7 @@ class DemoLoyalty
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]));
@@ -208,8 +227,8 @@ class DemoLoyalty
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_LoyaltyClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new LoyaltyClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -255,8 +274,8 @@ class DemoLoyalty
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -299,36 +318,36 @@ class DemoLoyalty
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject
-    $newObject = new Google_Service_Walletobjects_LoyaltyObject([
+    $newObject = new LoyaltyObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -336,13 +355,13 @@ class DemoLoyalty
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -351,20 +370,20 @@ class DemoLoyalty
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'accountId' => 'Account ID',
       'accountName' => 'Account name',
-      'loyaltyPoints' => new Google_Service_Walletobjects_LoyaltyPoints([
-        'balance' => new Google_Service_Walletobjects_LoyaltyPointsBalance([
+      'loyaltyPoints' => new LoyaltyPoints([
+        'balance' => new LoyaltyPointsBalance([
           'int' => 800
         ])
       ])
@@ -407,7 +426,7 @@ class DemoLoyalty
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -415,7 +434,7 @@ class DemoLoyalty
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -463,17 +482,17 @@ class DemoLoyalty
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_LoyaltyObject();
+    $patchBody = new LoyaltyObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -524,7 +543,7 @@ class DemoLoyalty
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_LoyaltyObject([
+    $patchBody = new LoyaltyObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -564,8 +583,8 @@ class DemoLoyalty
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -599,17 +618,17 @@ class DemoLoyalty
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyclass
-    $newClass = new Google_Service_Walletobjects_LoyaltyClass([
+    $newClass = new LoyaltyClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
       'programName' => 'Program name',
-      'programLogo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'programLogo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'http://farm8.staticflickr.com/7340/11177041185_a61a7f2139_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Logo description'
           ])
@@ -619,36 +638,36 @@ class DemoLoyalty
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject
-    $newObject = new Google_Service_Walletobjects_LoyaltyObject([
+    $newObject = new LoyaltyObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -656,13 +675,13 @@ class DemoLoyalty
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -671,20 +690,20 @@ class DemoLoyalty
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
       'accountId' => 'Account ID',
       'accountName' => 'Account name',
-      'loyaltyPoints' => new Google_Service_Walletobjects_LoyaltyPoints([
-        'balance' => new Google_Service_Walletobjects_LoyaltyPointsBalance([
+      'loyaltyPoints' => new LoyaltyPoints([
+        'balance' => new LoyaltyPointsBalance([
           'int' => 800
         ])
       ])
@@ -850,36 +869,36 @@ class DemoLoyalty
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/retail/loyalty-cards/rest/v1/loyaltyobject
-      $batchObject = new Google_Service_Walletobjects_LoyaltyObject([
+      $batchObject = new LoyaltyObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -887,13 +906,13 @@ class DemoLoyalty
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -902,20 +921,20 @@ class DemoLoyalty
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
         ],
         'accountId' => 'Account ID',
         'accountName' => 'Account name',
-        'loyaltyPoints' => new Google_Service_Walletobjects_LoyaltyPoints([
-          'balance' => new Google_Service_Walletobjects_LoyaltyPointsBalance([
+        'loyaltyPoints' => new LoyaltyPoints([
+          'balance' => new LoyaltyPointsBalance([
             'int' => 800
           ])
         ])

--- a/php/demo_loyalty.php
+++ b/php/demo_loyalty.php
@@ -80,17 +80,15 @@ class DemoLoyalty
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_offer.php
+++ b/php/demo_offer.php
@@ -17,20 +17,39 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\DateTime;
+use Google\Service\Walletobjects\TimeInterval;
+use Google\Service\Walletobjects\OfferObject;
+use Google\Service\Walletobjects\OfferClass;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
 // [END imports]
 
 /** Demo class for creating and managing Offers in Google Wallet. */
 class DemoOffer
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +64,7 @@ class DemoOffer
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +88,12 @@ class DemoOffer
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,7 +124,7 @@ class DemoOffer
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/offers/rest/v1/offerclass
-    $newClass = new Google_Service_Walletobjects_OfferClass([
+    $newClass = new OfferClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
@@ -152,7 +171,7 @@ class DemoOffer
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]));
@@ -198,8 +217,8 @@ class DemoOffer
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_OfferClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new OfferClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -245,8 +264,8 @@ class DemoOffer
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -289,36 +308,36 @@ class DemoOffer
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/offers/rest/v1/offerobject
-    $newObject = new Google_Service_Walletobjects_OfferObject([
+    $newObject = new OfferObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -326,13 +345,13 @@ class DemoOffer
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -341,21 +360,21 @@ class DemoOffer
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
-      'validTimeInterval' => new Google_Service_Walletobjects_TimeInterval([
-        'start' => new Google_Service_Walletobjects_DateTime([
+      'validTimeInterval' => new TimeInterval([
+        'start' => new DateTime([
           'date' => '2023-06-12T23:20:50.52Z'
         ]),
-        'end' => new Google_Service_Walletobjects_DateTime([
+        'end' => new DateTime([
           'date' => '2023-12-12T23:20:50.52Z'
         ])
       ])
@@ -398,7 +417,7 @@ class DemoOffer
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -406,7 +425,7 @@ class DemoOffer
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -454,17 +473,17 @@ class DemoOffer
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_OfferObject();
+    $patchBody = new OfferObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -515,7 +534,7 @@ class DemoOffer
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_OfferObject([
+    $patchBody = new OfferObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -555,8 +574,8 @@ class DemoOffer
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -590,7 +609,7 @@ class DemoOffer
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/offers/rest/v1/offerclass
-    $newClass = new Google_Service_Walletobjects_OfferClass([
+    $newClass = new OfferClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
@@ -601,36 +620,36 @@ class DemoOffer
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/retail/offers/rest/v1/offerobject
-    $newObject = new Google_Service_Walletobjects_OfferObject([
+    $newObject = new OfferObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -638,13 +657,13 @@ class DemoOffer
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -653,21 +672,21 @@ class DemoOffer
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
       ],
-      'validTimeInterval' => new Google_Service_Walletobjects_TimeInterval([
-        'start' => new Google_Service_Walletobjects_DateTime([
+      'validTimeInterval' => new TimeInterval([
+        'start' => new DateTime([
           'date' => '2023-06-12T23:20:50.52Z'
         ]),
-        'end' => new Google_Service_Walletobjects_DateTime([
+        'end' => new DateTime([
           'date' => '2023-12-12T23:20:50.52Z'
         ])
       ])
@@ -833,36 +852,36 @@ class DemoOffer
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/retail/offers/rest/v1/offerobject
-      $batchObject = new Google_Service_Walletobjects_OfferObject([
+      $batchObject = new OfferObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -870,13 +889,13 @@ class DemoOffer
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -885,21 +904,21 @@ class DemoOffer
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
         ],
-        'validTimeInterval' => new Google_Service_Walletobjects_TimeInterval([
-          'start' => new Google_Service_Walletobjects_DateTime([
+        'validTimeInterval' => new TimeInterval([
+          'start' => new DateTime([
             'date' => '2023-06-12T23:20:50.52Z'
           ]),
-          'end' => new Google_Service_Walletobjects_DateTime([
+          'end' => new DateTime([
             'date' => '2023-12-12T23:20:50.52Z'
           ])
         ])

--- a/php/demo_offer.php
+++ b/php/demo_offer.php
@@ -80,17 +80,15 @@ class DemoOffer
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_transit.php
+++ b/php/demo_transit.php
@@ -79,17 +79,15 @@ class DemoTransit
    */
   public function auth()
   {
-    $scope = 'https://www.googleapis.com/auth/wallet_object.issuer';
-
     $this->credentials = new ServiceAccountCredentials(
-      $scope,
+      Walletobjects::WALLET_OBJECT_ISSUER,
       $this->keyFilePath
     );
 
     // Initialize Google Wallet API service
     $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
-    $this->client->setScopes($scope);
+    $this->client->setScopes(Walletobjects::WALLET_OBJECT_ISSUER);
     $this->client->setAuthConfig($this->keyFilePath);
 
     $this->service = new Walletobjects($this->client);

--- a/php/demo_transit.php
+++ b/php/demo_transit.php
@@ -17,20 +17,38 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-// Download the PHP client library from the following URL
-// https://developers.google.com/wallet/generic/resources/libraries
-require __DIR__ . '/lib/Walletobjects.php';
-
 // [START setup]
 // [START imports]
 use Firebase\JWT\JWT;
 use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Client as Google_Client;
+use Google\Client as GoogleClient;
+use Google\Service\Walletobjects;
+use Google\Service\Walletobjects\TicketLeg;
+use Google\Service\Walletobjects\LatLongPoint;
+use Google\Service\Walletobjects\Barcode;
+use Google\Service\Walletobjects\ImageModuleData;
+use Google\Service\Walletobjects\LinksModuleData;
+use Google\Service\Walletobjects\TextModuleData;
+use Google\Service\Walletobjects\TransitObject;
+use Google\Service\Walletobjects\Message;
+use Google\Service\Walletobjects\AddMessageRequest;
+use Google\Service\Walletobjects\Uri;
+use Google\Service\Walletobjects\TranslatedString;
+use Google\Service\Walletobjects\LocalizedString;
+use Google\Service\Walletobjects\ImageUri;
+use Google\Service\Walletobjects\Image;
+use Google\Service\Walletobjects\TransitClass;
 // [END imports]
 
 /** Demo class for creating and managing Transit passes in Google Wallet. */
 class DemoTransit
 {
+  /**
+   * The Google API Client
+   * https://github.com/google/google-api-php-client
+   */
+  public GoogleClient $client;
+
   /**
    * Path to service account key file from Google Cloud Console. Environment
    * variable: GOOGLE_APPLICATION_CREDENTIALS.
@@ -45,7 +63,7 @@ class DemoTransit
   /**
    * Google Wallet service client.
    */
-  public Google_Service_Walletobjects $service;
+  public Walletobjects $service;
 
   public function __construct()
   {
@@ -69,12 +87,12 @@ class DemoTransit
     );
 
     // Initialize Google Wallet API service
-    $this->client = new Google_Client();
+    $this->client = new GoogleClient();
     $this->client->setApplicationName('APPLICATION_NAME');
     $this->client->setScopes($scope);
     $this->client->setAuthConfig($this->keyFilePath);
 
-    $this->service = new Google_Service_Walletobjects($this->client);
+    $this->service = new Walletobjects($this->client);
   }
   // [END auth]
 
@@ -105,16 +123,16 @@ class DemoTransit
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitclass
-    $newClass = new Google_Service_Walletobjects_TransitClass([
+    $newClass = new TransitClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
-      'logo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'logo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://live.staticflickr.com/65535/48690277162_cd05f03f4d_o.png'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Logo description'
           ])
@@ -161,7 +179,7 @@ class DemoTransit
     }
 
     // Update the class by adding a homepage
-    $updatedClass->setHomepageUri(new Google_Service_Walletobjects_Uri([
+    $updatedClass->setHomepageUri(new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'Homepage description'
     ]));
@@ -207,8 +225,8 @@ class DemoTransit
     }
 
     // Patch the class by adding a homepage
-    $patchBody = new Google_Service_Walletobjects_TransitClass([
-      'homepageUri' => new Google_Service_Walletobjects_Uri([
+    $patchBody = new TransitClass([
+      'homepageUri' => new Uri([
         'uri' => 'https://developers.google.com/wallet',
         'description' => 'Homepage description'
       ]),
@@ -254,8 +272,8 @@ class DemoTransit
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -298,36 +316,36 @@ class DemoTransit
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitobject
-    $newObject = new Google_Service_Walletobjects_TransitObject([
+    $newObject = new TransitObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -335,13 +353,13 @@ class DemoTransit
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -350,12 +368,12 @@ class DemoTransit
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
@@ -363,25 +381,25 @@ class DemoTransit
       'passengerType' => 'SINGLE_PASSENGER',
       'passengerNames' => 'Passenger names',
       'tripType' => 'ONE_WAY',
-      'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
+      'ticketLeg' => new TicketLeg([
         'originStationCode' => 'LA',
-        'originName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'originName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Origin name'
           ])
         ]),
         'destinationStationCode' => 'SFO',
-        'destinationName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'destinationName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Destination name'
           ])
         ]),
         'departureDateTime' => '2020-04-12T16:20:50.52Z',
         'arrivalDateTime' => '2020-04-12T20:20:50.52Z',
-        'fareName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'fareName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Fare name'
           ])
@@ -426,7 +444,7 @@ class DemoTransit
     }
 
     // Update the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
@@ -434,7 +452,7 @@ class DemoTransit
     $linksModuleData = $updatedObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -482,17 +500,17 @@ class DemoTransit
     }
 
     // Patch the object by adding a link
-    $newLink = new Google_Service_Walletobjects_Uri([
+    $newLink = new Uri([
       'uri' => 'https://developers.google.com/wallet',
       'description' => 'New link description'
     ]);
 
-    $patchBody = new Google_Service_Walletobjects_TransitObject();
+    $patchBody = new TransitObject();
 
     $linksModuleData = $existingObject->getLinksModuleData();
     if (is_null($linksModuleData)) {
       // LinksModuleData was not set on the original object
-      $linksModuleData = new Google_Service_Walletobjects_LinksModuleData([
+      $linksModuleData = new LinksModuleData([
         'uris' => []
       ]);
     }
@@ -543,7 +561,7 @@ class DemoTransit
     }
 
     // Patch the object, setting the pass as expired
-    $patchBody = new Google_Service_Walletobjects_TransitObject([
+    $patchBody = new TransitObject([
       'state' => 'EXPIRED'
     ]);
 
@@ -583,8 +601,8 @@ class DemoTransit
       }
     }
 
-    $message = new Google_Service_Walletobjects_AddMessageRequest([
-      'message' => new Google_Service_Walletobjects_Message([
+    $message = new AddMessageRequest([
+      'message' => new Message([
         'header' => $header,
         'body' => $body
       ])
@@ -618,16 +636,16 @@ class DemoTransit
   {
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitclass
-    $newClass = new Google_Service_Walletobjects_TransitClass([
+    $newClass = new TransitClass([
       'id' => "{$issuerId}.{$classSuffix}",
       'issuerName' => 'Issuer name',
       'reviewStatus' => 'UNDER_REVIEW',
-      'logo' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'logo' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://live.staticflickr.com/65535/48690277162_cd05f03f4d_o.png'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Logo description'
           ])
@@ -638,36 +656,36 @@ class DemoTransit
 
     // See link below for more information on required properties
     // https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitobject
-    $newObject = new Google_Service_Walletobjects_TransitObject([
+    $newObject = new TransitObject([
       'id' => "{$issuerId}.{$objectSuffix}",
       'classId' => "{$issuerId}.{$classSuffix}",
       'state' => 'ACTIVE',
-      'heroImage' => new Google_Service_Walletobjects_Image([
-        'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+      'heroImage' => new Image([
+        'sourceUri' => new ImageUri([
           'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
         ]),
-        'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'contentDescription' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Hero image description'
           ])
         ])
       ]),
       'textModulesData' => [
-        new Google_Service_Walletobjects_TextModuleData([
+        new TextModuleData([
           'header' => 'Text module header',
           'body' => 'Text module body',
           'id' => 'TEXT_MODULE_ID'
         ])
       ],
-      'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+      'linksModuleData' => new LinksModuleData([
         'uris' => [
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'http://maps.google.com/',
             'description' => 'Link module URI description',
             'id' => 'LINK_MODULE_URI_ID'
           ]),
-          new Google_Service_Walletobjects_Uri([
+          new Uri([
             'uri' => 'tel:6505555555',
             'description' => 'Link module tel description',
             'id' => 'LINK_MODULE_TEL_ID'
@@ -675,13 +693,13 @@ class DemoTransit
         ]
       ]),
       'imageModulesData' => [
-        new Google_Service_Walletobjects_ImageModuleData([
-          'mainImage' => new Google_Service_Walletobjects_Image([
-            'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        new ImageModuleData([
+          'mainImage' => new Image([
+            'sourceUri' => new ImageUri([
               'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
             ]),
-            'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-              'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+            'contentDescription' => new LocalizedString([
+              'defaultValue' => new TranslatedString([
                 'language' => 'en-US',
                 'value' => 'Image module description'
               ])
@@ -690,12 +708,12 @@ class DemoTransit
           'id' => 'IMAGE_MODULE_ID'
         ])
       ],
-      'barcode' => new Google_Service_Walletobjects_Barcode([
+      'barcode' => new Barcode([
         'type' => 'QR_CODE',
         'value' => 'QR code value'
       ]),
       'locations' => [
-        new Google_Service_Walletobjects_LatLongPoint([
+        new LatLongPoint([
           'latitude' => 37.424015499999996,
           'longitude' =>  -122.09259560000001
         ])
@@ -703,25 +721,25 @@ class DemoTransit
       'passengerType' => 'SINGLE_PASSENGER',
       'passengerNames' => 'Passenger names',
       'tripType' => 'ONE_WAY',
-      'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
+      'ticketLeg' => new TicketLeg([
         'originStationCode' => 'LA',
-        'originName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'originName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Origin name'
           ])
         ]),
         'destinationStationCode' => 'SFO',
-        'destinationName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'destinationName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Destination name'
           ])
         ]),
         'departureDateTime' => '2020-04-12T16:20:50.52Z',
         'arrivalDateTime' => '2020-04-12T20:20:50.52Z',
-        'fareName' => new Google_Service_Walletobjects_LocalizedString([
-          'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+        'fareName' => new LocalizedString([
+          'defaultValue' => new TranslatedString([
             'language' => 'en-US',
             'value' => 'Fare name'
           ])
@@ -889,36 +907,36 @@ class DemoTransit
 
       // See link below for more information on required properties
       // https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitobject
-      $batchObject = new Google_Service_Walletobjects_TransitObject([
+      $batchObject = new TransitObject([
         'id' => "{$issuerId}.{$objectSuffix}",
         'classId' => "{$issuerId}.{$classSuffix}",
         'state' => 'ACTIVE',
-        'heroImage' => new Google_Service_Walletobjects_Image([
-          'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+        'heroImage' => new Image([
+          'sourceUri' => new ImageUri([
             'uri' => 'https://farm4.staticflickr.com/3723/11177041115_6e6a3b6f49_o.jpg'
           ]),
-          'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'contentDescription' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Hero image description'
             ])
           ])
         ]),
         'textModulesData' => [
-          new Google_Service_Walletobjects_TextModuleData([
+          new TextModuleData([
             'header' => 'Text module header',
             'body' => 'Text module body',
             'id' => 'TEXT_MODULE_ID'
           ])
         ],
-        'linksModuleData' => new Google_Service_Walletobjects_LinksModuleData([
+        'linksModuleData' => new LinksModuleData([
           'uris' => [
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'http://maps.google.com/',
               'description' => 'Link module URI description',
               'id' => 'LINK_MODULE_URI_ID'
             ]),
-            new Google_Service_Walletobjects_Uri([
+            new Uri([
               'uri' => 'tel:6505555555',
               'description' => 'Link module tel description',
               'id' => 'LINK_MODULE_TEL_ID'
@@ -926,13 +944,13 @@ class DemoTransit
           ]
         ]),
         'imageModulesData' => [
-          new Google_Service_Walletobjects_ImageModuleData([
-            'mainImage' => new Google_Service_Walletobjects_Image([
-              'sourceUri' => new Google_Service_Walletobjects_ImageUri([
+          new ImageModuleData([
+            'mainImage' => new Image([
+              'sourceUri' => new ImageUri([
                 'uri' => 'http://farm4.staticflickr.com/3738/12440799783_3dc3c20606_b.jpg'
               ]),
-              'contentDescription' => new Google_Service_Walletobjects_LocalizedString([
-                'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+              'contentDescription' => new LocalizedString([
+                'defaultValue' => new TranslatedString([
                   'language' => 'en-US',
                   'value' => 'Image module description'
                 ])
@@ -941,12 +959,12 @@ class DemoTransit
             'id' => 'IMAGE_MODULE_ID'
           ])
         ],
-        'barcode' => new Google_Service_Walletobjects_Barcode([
+        'barcode' => new Barcode([
           'type' => 'QR_CODE',
           'value' => 'QR code value'
         ]),
         'locations' => [
-          new Google_Service_Walletobjects_LatLongPoint([
+          new LatLongPoint([
             'latitude' => 37.424015499999996,
             'longitude' =>  -122.09259560000001
           ])
@@ -954,25 +972,25 @@ class DemoTransit
         'passengerType' => 'SINGLE_PASSENGER',
         'passengerNames' => 'Passenger names',
         'tripType' => 'ONE_WAY',
-        'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
+        'ticketLeg' => new TicketLeg([
           'originStationCode' => 'LA',
-          'originName' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'originName' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Origin name'
             ])
           ]),
           'destinationStationCode' => 'SFO',
-          'destinationName' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'destinationName' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Destination name'
             ])
           ]),
           'departureDateTime' => '2020-04-12T16:20:50.52Z',
           'arrivalDateTime' => '2020-04-12T20:20:50.52Z',
-          'fareName' => new Google_Service_Walletobjects_LocalizedString([
-            'defaultValue' => new Google_Service_Walletobjects_TranslatedString([
+          'fareName' => new LocalizedString([
+            'defaultValue' => new TranslatedString([
               'language' => 'en-US',
               'value' => 'Fare name'
             ])


### PR DESCRIPTION
[Google Wallet API Client library ](https://developers.google.com/wallet/generic/resources/libraries#php) should not be downloaded and included manually, as it is now installed by `composer` from [github.com/google/apiclient-services](https://github.com/googleapis/google-api-php-client-services/), here is the [source](https://github.com/googleapis/google-api-php-client-services/blob/main/src/Walletobjects.php).

Also, according to [Google PHP API Client UPGRADING.md](https://github.com/googleapis/google-api-php-client/blob/main/UPGRADING.md), since version `2.10.0` the Google SDKs classes are namespaced so we should use those.

As discussed in #75