### PR TITLE
transitObjects should be lowerCamelCase when creating a JWT with C#

### DIFF
--- a/dotnet/DemoTransit.cs
+++ b/dotnet/DemoTransit.cs
@@ -946,7 +946,7 @@ class DemoTransit
         {
           serializedClass
         },
-        TransitObjects = new List<JObject>
+        transitObjects = new List<JObject>
         {
           serializedObject
         }


### PR DESCRIPTION
According to the [Google Wallet API JWT spec](https://developers.google.com/wallet/reference/rest/v1/Jwt), the field `transitObjects` should be written in lowerCamelCase. This PR fixes the C# demo for transit passes, which was using UpperCamelCase for this JWT field name. 